### PR TITLE
Simplify workflow graph

### DIFF
--- a/src/nomad_parser_pwd/parsers/parser.py
+++ b/src/nomad_parser_pwd/parsers/parser.py
@@ -452,11 +452,14 @@ class PythonWorkflowDefinitionParser(MatchingParser):
                     workflow.name = f'Python Workflow Definition: {base_name}'
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
                 # Validate using the Pydantic model
                 data = PythonWorkflowDefinitionWorkflow.load_json_str(file_content)
 
 >>>>>>> 9450628 (refactor: use upstream library validation instead of json workaround)
+=======
+>>>>>>> 387d2c3 (remove redundant parsing call)
                 # Load into the NOMAD section
                 workflow.load_from_pydantic_model(data)
 

--- a/src/nomad_parser_pwd/parsers/parser.py
+++ b/src/nomad_parser_pwd/parsers/parser.py
@@ -451,6 +451,12 @@ class PythonWorkflowDefinitionParser(MatchingParser):
                     base_name = os.path.splitext(os.path.basename(mainfile))[0]
                     workflow.name = f'Python Workflow Definition: {base_name}'
 
+<<<<<<< HEAD
+=======
+                # Validate using the Pydantic model
+                data = PythonWorkflowDefinitionWorkflow.load_json_str(file_content)
+
+>>>>>>> 9450628 (refactor: use upstream library validation instead of json workaround)
                 # Load into the NOMAD section
                 workflow.load_from_pydantic_model(data)
 

--- a/src/nomad_parser_pwd/parsers/parser.py
+++ b/src/nomad_parser_pwd/parsers/parser.py
@@ -451,15 +451,6 @@ class PythonWorkflowDefinitionParser(MatchingParser):
                     base_name = os.path.splitext(os.path.basename(mainfile))[0]
                     workflow.name = f'Python Workflow Definition: {base_name}'
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-                # Validate using the Pydantic model
-                data = PythonWorkflowDefinitionWorkflow.load_json_str(file_content)
-
->>>>>>> 9450628 (refactor: use upstream library validation instead of json workaround)
-=======
->>>>>>> 387d2c3 (remove redundant parsing call)
                 # Load into the NOMAD section
                 workflow.load_from_pydantic_model(data)
 

--- a/tests/parsers/test_parser.py
+++ b/tests/parsers/test_parser.py
@@ -58,6 +58,20 @@ def test_data_path():
     return Path(__file__).parent.parent / 'data'
 
 
+def get_all_tasks(workflow):
+    """
+    Helper to return a flat list of all tasks, including those inside
+    the 'Utility Functions' sub-workflow.
+    """
+    all_tasks = []
+    for task in workflow.tasks:
+        if getattr(task, 'name', '') == 'Utility Functions':
+            all_tasks.extend(task.tasks)
+        else:
+            all_tasks.append(task)
+    return all_tasks
+
+
 def test_parser_instantiation(parser):
     """Test that the parser can be instantiated."""
     assert parser is not None
@@ -294,6 +308,8 @@ def test_edge_parsing_basic_structure(parser, test_data_path):
     parser.parse(str(workflow_json_path), archive, None)
     workflow = archive.workflow2
 
+    all_tasks = get_all_tasks(workflow)
+
     # Verify NOMAD workflow structures are created
     assert len(workflow.inputs) > 0
     assert len(workflow.outputs) > 0
@@ -302,10 +318,10 @@ def test_edge_parsing_basic_structure(parser, test_data_path):
     # Check that we have the expected number of each type
     assert len(workflow.inputs) >= ARITHMETIC_INPUTS  # x, y inputs
     assert len(workflow.outputs) >= ARITHMETIC_OUTPUTS  # result output
-    assert len(workflow.tasks) >= ARITHMETIC_FUNCTIONS  # function tasks
+    assert len(all_tasks) >= ARITHMETIC_FUNCTIONS  # function tasks
 
     # Check that tasks have the right properties
-    for task in workflow.tasks:
+    for task in all_tasks:
         assert task.node_type == 'function'
         assert task.node_id is not None
         assert task.module_function is not None
@@ -324,7 +340,7 @@ def test_edge_to_connection_mapping(parser, test_data_path):
     workflow = archive.workflow2
 
     edges = raw_data['edges']
-    function_tasks = [t for t in workflow.workflow_tasks if t.node_type == 'function']
+    function_tasks = [t for t in get_all_tasks(workflow) if t.node_type == 'function']
 
     # Verify that each edge creates appropriate connections
     for task in function_tasks:
@@ -353,7 +369,7 @@ def test_port_name_mapping(parser, test_data_path):
     workflow = archive.workflow2
 
     edges = raw_data['edges']
-    function_tasks = [t for t in workflow.workflow_tasks if t.node_type == 'function']
+    function_tasks = [t for t in get_all_tasks(workflow) if t.node_type == 'function']
 
     # Check first function task (get_prod_and_div)
     first_task = function_tasks[0]
@@ -381,9 +397,11 @@ def test_value_section_references(parser, test_data_path):
     parser.parse(str(workflow_json_path), archive, None)
     workflow = archive.workflow2
 
+    all_tasks = get_all_tasks(workflow)
+
     # Collect all valid sections (tasks, input/output task sections)
     valid_sections = set()
-    for task in workflow.tasks:
+    for task in all_tasks:
         valid_sections.add(task)
         # Add input/output task sections
         for input_link in task.inputs:
@@ -401,7 +419,7 @@ def test_value_section_references(parser, test_data_path):
         if workflow_output.section:
             valid_sections.add(workflow_output.section)
 
-    function_tasks = [t for t in workflow.workflow_tasks if t.node_type == 'function']
+    function_tasks = [t for t in all_tasks if t.node_type == 'function']
 
     for task in function_tasks:
         # Check that all input connections reference valid sections
@@ -462,13 +480,14 @@ def test_edge_parsing_complex_workflow(parser, test_data_path):
 
     # Verify comprehensive edge processing
     # Should have created tasks and connections
-    total_entities = len(workflow.tasks) + len(workflow.inputs) + len(workflow.outputs)
+    all_tasks = get_all_tasks(workflow)
+    total_entities = len(all_tasks) + len(workflow.inputs) + len(workflow.outputs)
     assert total_entities >= len(nodes)
     assert workflow.results.n_edges == len(edges)
 
     # Check that all function nodes have corresponding tasks
     function_nodes = [n for n in nodes if n['type'] == 'function']
-    function_tasks = [t for t in workflow.workflow_tasks if t.node_type == 'function']
+    function_tasks = [t for t in all_tasks if t.node_type == 'function']
     assert len(function_tasks) == len(function_nodes)
 
     # Verify total connection count makes sense
@@ -505,7 +524,8 @@ def test_multiple_output_ports(parser, test_data_path):
 
     if len(source_ports) > 1:  # If we have multiple output ports
         # Find the corresponding task
-        task_0 = next((t for t in workflow.workflow_tasks if t.node_id == 0), None)
+        all_tasks = get_all_tasks(workflow)
+        task_0 = next((t for t in all_tasks if t.node_id == 0), None)
         assert task_0 is not None
 
         # Should have output for each source port
@@ -545,7 +565,8 @@ def test_edge_parsing_preserves_values(parser, test_data_path):
 
         if node['type'] == 'function':
             # Find corresponding task
-            task = next((t for t in workflow.tasks if t.node_id == node['id']), None)
+            all_tasks = get_all_tasks(workflow)
+            task = next((t for t in all_tasks if t.node_id == node['id']), None)
             assert task is not None
             assert task.module_function == node['value']
 
@@ -578,12 +599,12 @@ def test_edge_connection_matching_for_nomad_visualization(parser, test_data_path
         for e in edges
         if any(
             t.node_id == e['source']
-            for t in workflow.workflow_tasks
+            for t in get_all_tasks(workflow)
             if t.node_type == 'function'
         )
         and any(
             t.node_id == e['target']
-            for t in workflow.workflow_tasks
+            for t in get_all_tasks(workflow)
             if t.node_type == 'function'
         )
     ]
@@ -591,10 +612,10 @@ def test_edge_connection_matching_for_nomad_visualization(parser, test_data_path
     # Each function-to-function edge must have matching connections
     for edge in function_to_function_edges:
         source_task = next(
-            (t for t in workflow.workflow_tasks if t.node_id == edge['source']), None
+            (t for t in get_all_tasks(workflow) if t.node_id == edge['source']), None
         )
         target_task = next(
-            (t for t in workflow.workflow_tasks if t.node_id == edge['target']), None
+            (t for t in get_all_tasks(workflow) if t.node_id == edge['target']), None
         )
 
         assert source_task is not None, f'Source task not found for edge {edge}'
@@ -655,12 +676,12 @@ def test_edge_matching_quantum_espresso(parser, test_data_path):
         for e in edges
         if any(
             t.node_id == e['source']
-            for t in workflow.workflow_tasks
+            for t in get_all_tasks(workflow)
             if t.node_type == 'function'
         )
         and any(
             t.node_id == e['target']
-            for t in workflow.workflow_tasks
+            for t in get_all_tasks(workflow)
             if t.node_type == 'function'
         )
     ]
@@ -677,10 +698,10 @@ def test_edge_matching_quantum_espresso(parser, test_data_path):
     # Validate each function-to-function edge
     for edge in function_to_function_edges:
         source_task = next(
-            (t for t in workflow.workflow_tasks if t.node_id == edge['source']), None
+            (t for t in get_all_tasks(workflow) if t.node_id == edge['source']), None
         )
         target_task = next(
-            (t for t in workflow.workflow_tasks if t.node_id == edge['target']), None
+            (t for t in get_all_tasks(workflow) if t.node_id == edge['target']), None
         )
 
         if source_task is None or target_task is None:
@@ -763,7 +784,7 @@ def test_function_to_output_connections_regression(parser, test_data_path):
     if node_2_to_5_edge is not None:
         # Find the corresponding function task
         source_task = next(
-            (t for t in workflow.workflow_tasks if t.node_id == FUNCTION_NODE_ID), None
+            (t for t in get_all_tasks(workflow) if t.node_id == FUNCTION_NODE_ID), None
         )
         assert source_task is not None, 'Task for node 2 not found'
 
@@ -816,7 +837,7 @@ def test_parsing_new_quantities(parser, test_data_path):
     # Iterate through tasks and verify our new data exists
     tasks_with_new_data = 0
 
-    for task in workflow.tasks:
+    for task in get_all_tasks(workflow):
         # Check 'working_directory' (Should be a string)
         if task.working_directory:
             assert isinstance(task.working_directory, str)
@@ -910,3 +931,76 @@ def test_task_reference_resolution(tmp_path):
     # MProxy objects string representation wraps the value (e.g. MProxy(value))
     # We check if the expected link is inside the string representation
     assert expected_link in str(result_task.task)
+
+def test_workflow_simplification(parser, test_data_path):
+    """
+    Test that the workflow graph is simplified by grouping utility tasks
+    (tasks without working_directory) into a 'Utility Functions' sub-workflow.
+    """
+    # Locate the file (using data_export as it contains the working_directory fields)
+    workflow_json_path = test_data_path / 'data_export' / 'workflow.json'
+
+    # Safety check consistent with other tests
+    if not workflow_json_path.exists():
+        pytest.skip(
+            f'Test data not found at {workflow_json_path}. Please create it first.'
+        )
+
+    # Parse the file
+    archive = EntryArchive()
+    parser.parse(str(workflow_json_path), archive, None)
+
+    workflow = archive.workflow2
+    assert workflow is not None
+
+    # 1. Inspect the Top-Level Tasks
+    # We expect "Main Tasks" (with working_dir) + 1 "Utility Functions" Workflow
+
+    top_level_tasks = workflow.tasks
+
+    # Identify the sub-workflow
+    # We look for the object by name as created in the normalize() method
+    utility_workflows = [t for t in top_level_tasks if t.name == 'Utility Functions']
+
+    assert len(utility_workflows) == 1, (
+        f"Expected 1 'Utility Functions' sub-workflow, found {len(utility_workflows)}"
+    )
+
+    # Identify Main Tasks at top level
+    main_tasks = [t for t in top_level_tasks if t.name != 'Utility Functions']
+
+    # Verify main tasks have working directories
+    for task in main_tasks:
+        # Check if attribute exists and is truthy.
+        assert task.working_directory, (
+            f'Top level task {task.name} missing\
+              working_directory'
+        )
+
+    # 2. Inspect the Sub-Workflow Content
+    utility_workflow = utility_workflows[0]
+
+    # Check that it contains tasks
+    assert len(utility_workflow.tasks) > 0, 'Utility workflow should not be empty'
+
+    # Verify tasks inside are actually utilities (no working directory)
+    for task in utility_workflow.tasks:
+        if hasattr(task, 'working_directory'):
+            assert not task.working_directory, (
+                f'Task {task.name} in utility workflow has \
+                    working_directory: {task.working_directory}'
+            )
+
+    # 3. Verify specific counts based on the sample json
+    # (Nodes 0, 2, 5, 8, 10, 12, 14 have working directories -> 7 Main)
+    # (Nodes 1, 3, 4, 6, 7, 9, 11, 13, 15, 16 have null -> 10 Utility)
+    count_main_tasks = 7
+    count_utility_tasks = 10
+    assert len(main_tasks) == count_main_tasks, (
+        f'\
+        Expected 7 main tasks, got {len(main_tasks)}'
+    )
+    assert len(utility_workflow.tasks) == count_utility_tasks, (
+        f'\
+        Expected 10 utility tasks, got {len(utility_workflow.tasks)}'
+    )


### PR DESCRIPTION
**Schema Refactor (pwd.py):**

- Implemented normalize() to move utility tasks (no working_directory) into a "Utility Functions" sub-workflow.

- Updated n_edges, n_function_nodes, and get_pydantic_model() to flatten the task hierarchy, ensuring accurate statistics and exports.

**Parser Update (parser.py):**

- Refactored logging to safely handle mixed object types, preventing crashes when encountering the new sub-workflow container (which lacks a node_id).
- Adjusting the is_mainfile() function to ensure it identifies the workflow.json as a mainfile. The uploaded JSON file is chunked (?), and then it fails to be detected as a main file. However, with the new condition added, it passed successfully. Let me know if you have any ideas to make it more general/nice.

**Test Suite (test_parser.py):**

- Added test_workflow_simplification to verify the hierarchy logic.

- Created get_all_tasks() helper to flatten the graph for regression tests, allowing existing validation logic to pass.
